### PR TITLE
feat(voyages): sécuriser la création d'un voyage avec JWT et gérer le…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/config": "^4.0.1",
         "@nestjs/core": "^11.0.12",
         "@nestjs/jwt": "^11.0.0",
+        "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.12",
         "@nestjs/platform-socket.io": "^11.0.12",
         "@nestjs/swagger": "^11.0.7",
@@ -2426,6 +2427,16 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/passport": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
+      "integrity": "sha512-ulQX6mbjlws92PIM15Naes4F4p2JoxGnIJuUsdXQPT+Oo2sqQmENEZXM7eYuimocfHnKlcfZOuyzbA33LwUlOQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "passport": "^0.5.0 || ^0.6.0 || ^0.7.0"
       }
     },
     "node_modules/@nestjs/platform-express": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/config": "^4.0.1",
     "@nestjs/core": "^11.0.12",
     "@nestjs/jwt": "^11.0.0",
+    "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.12",
     "@nestjs/platform-socket.io": "^11.0.12",
     "@nestjs/swagger": "^11.0.7",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,20 +1,33 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
-import { DatabaseModule } from './core/database/database.module';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
+import { VoyageModule } from './voyage/voyage.module';
+import { UserEntity } from './auth/entities/user.entity';
+import { VoyageEntity } from './voyage/entities/voyage.entity';
+import { ActiviteEntity } from './voyage/entities/activite.entity';
+import { LogementEntity } from './voyage/entities/logement.entity';
+import { TransportEntity } from './voyage/entities/transport.entity';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({
-      isGlobal: true,
-      envFilePath: `.env.${process.env.NODE_ENV || 'development'}`,
+    TypeOrmModule.forRoot({
+      type: 'mysql',
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT, 10) || 3306,
+      username: process.env.DB_USER || 'root',
+      password: process.env.DB_PASS || 'root',
+      database: process.env.DB_NAME || 'odysseygate',
+      entities: [
+        UserEntity,
+        VoyageEntity,
+        TransportEntity,
+        LogementEntity,
+        ActiviteEntity,
+      ],
+      synchronize: true, // à n'utiliser qu'en développement
     }),
-    DatabaseModule,
-    AuthModule
+    AuthModule,
+    VoyageModule,
   ],
-  controllers: [AppController],
-  providers: [AppService],
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,25 +8,36 @@ import { LoginDto } from './dto/login.dto';
 @ApiTags('Authentication')
 @Controller('auth')
 export class AuthController {
-    constructor(private readonly authService: AuthService) { }
+  constructor(private readonly authService: AuthService) {}
 
-    @Post('register')
-    @ApiOperation({ summary: `Inscription d\'un nouvel utilisateur` })
-    @ApiResponse({ status: 201, description: 'Utilisateur créé avec succès.', type: UserEntity })
-    @ApiResponse({ status: 400, description: 'Les mots de passe ne correspondent pas ou les données sont invalides.' })
-    @ApiResponse({ status: 409, description: 'L\'email est déjà utilisé.' })
-    async register(@Body() dto: RegisterUserDto): Promise<UserEntity> {
-        if (dto.password !== dto.confirmPassword) {
-            throw new BadRequestException('Passwords do not match');
-        }
-        return this.authService.register(dto);
+  @Post('register')
+  @ApiOperation({ summary: "Inscription d'un nouvel utilisateur" })
+  @ApiResponse({
+    status: 201,
+    description: 'Utilisateur créé avec succès.',
+    type: UserEntity,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Les mots de passe ne correspondent pas ou les données sont invalides.',
+  })
+  @ApiResponse({ status: 409, description: "L'email est déjà utilisé." })
+  async register(@Body() dto: RegisterUserDto): Promise<UserEntity> {
+    if (dto.password !== dto.confirmPassword) {
+      throw new BadRequestException('Les mots de passe ne correspondent pas.');
     }
+    return this.authService.register(dto);
+  }
 
-    @Post('login')
-    @ApiOperation({ summary: 'Connexion d\'un utilisateur existant' })
-    @ApiResponse({ status: 200, description: 'Connexion réussie. Retourne un token JWT.' })
-    @ApiResponse({ status: 401, description: 'Identifiants invalides.' })
-    async login(@Body() dto: LoginDto) {
-        return this.authService.login(dto);
-    }
+  @Post('login')
+  @ApiOperation({ summary: "Connexion d'un utilisateur existant" })
+  @ApiResponse({
+    status: 200,
+    description: 'Connexion réussie. Retourne un token JWT.',
+  })
+  @ApiResponse({ status: 401, description: 'Identifiants invalides.' })
+  async login(@Body() dto: LoginDto) {
+    return this.authService.login(dto);
+  }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,21 +1,23 @@
-// src/auth/auth.module.ts
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { UserEntity } from './entities/user.entity';
 import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { JwtStrategy } from './jwt.strategy';
 
 @Module({
-    imports: [
-        TypeOrmModule.forFeature([UserEntity]),
-        JwtModule.register({
-            secret: process.env.JWT_SECRET || 'odysseygatejwtsecret',
-            signOptions: { expiresIn: '1d' },
-        }),
-    ],
-    controllers: [AuthController],
-    providers: [AuthService],
-    exports: [AuthService],
+  imports: [
+    TypeOrmModule.forFeature([UserEntity]),
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'odysseygatejwtsecret',
+      signOptions: { expiresIn: '1d' },
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+  exports: [AuthService, PassportModule, JwtModule],
 })
-export class AuthModule { }
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, ConflictException, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  ConflictException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { RegisterUserDto } from './dto/register-user.dto';
@@ -9,52 +13,51 @@ import { JwtService } from '@nestjs/jwt';
 
 @Injectable()
 export class AuthService {
-    constructor(
-        @InjectRepository(UserEntity)
-        private readonly userRepository: Repository<UserEntity>,
-        private readonly jwtService: JwtService,
-    ) { }
+  constructor(
+    @InjectRepository(UserEntity)
+    private readonly userRepository: Repository<UserEntity>,
+    private readonly jwtService: JwtService,
+  ) {}
 
-    async register(dto: RegisterUserDto): Promise<UserEntity> {
-        // Vérifier si l'email existe déjà
-        const existingUser = await this.userRepository.findOneBy({ email: dto.email });
-        if (existingUser) {
-            throw new ConflictException('Email already in use');
-        }
-
-        // Hasher le mot de passe
-        const hashedPassword = await bcrypt.hash(dto.password, 10);
-
-        // Créer l'utilisateur
-        const user = this.userRepository.create({
-            nom: dto.nom,
-            prenom: dto.prenom,
-            email: dto.email,
-            password: hashedPassword,
-        });
-
-        // Sauvegarder l'utilisateur en base de données
-        return this.userRepository.save(user);
+  async register(dto: RegisterUserDto): Promise<UserEntity> {
+    // Vérifier si l'email existe déjà
+    const existingUser = await this.userRepository.findOneBy({
+      email: dto.email,
+    });
+    if (existingUser) {
+      throw new ConflictException('Email already in use');
     }
 
-    async login(dto: LoginDto): Promise<{ access_token: string }> {
-        // 1. Trouver l'utilisateur par email
-        const user = await this.userRepository.findOneBy({ email: dto.email });
-        if (!user) {
-            throw new UnauthorizedException('Invalid credentials (email)');
-        }
+    // Hasher le mot de passe
+    const hashedPassword = await bcrypt.hash(dto.password, 10);
 
-        // 2. Comparer le mot de passe
-        const isMatch = await bcrypt.compare(dto.password, user.password);
-        if (!isMatch) {
-            throw new UnauthorizedException('Invalid credentials (password)');
-        }
+    // Créer l'utilisateur
+    const user = this.userRepository.create({
+      nom: dto.nom,
+      prenom: dto.prenom,
+      email: dto.email,
+      password: hashedPassword,
+    });
 
-        // 3. Générer un token
-        const payload = { sub: user.id, email: user.email };
-        const access_token = await this.jwtService.signAsync(payload);
+    return this.userRepository.save(user);
+  }
 
-        // 4. Retourner le token
-        return { access_token };
+  async login(dto: LoginDto): Promise<{ access_token: string }> {
+    const user = await this.userRepository.findOne({
+      where: { email: dto.email },
+      select: ['id', 'email', 'password', 'nom', 'prenom'],
+    });
+    if (!user) {
+      throw new UnauthorizedException('Invalid credentials (email)');
     }
+
+    const isMatch = await bcrypt.compare(dto.password, user.password);
+    if (!isMatch) {
+      throw new UnauthorizedException('Invalid credentials (password)');
+    }
+
+    const payload = { sub: user.id, email: user.email };
+    const access_token = await this.jwtService.signAsync(payload);
+    return { access_token };
+  }
 }

--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -1,28 +1,41 @@
-// src/auth/entities/user.entity.ts
-
-import { Entity, PrimaryGeneratedColumn, Column, Unique } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  Unique,
+  OneToMany,
+} from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
+import { VoyageEntity } from '../../voyage/entities/voyage.entity';
 
 @Entity('users')
 @Unique(['email'])
 export class UserEntity {
-    @ApiProperty({ example: 1, description: 'Identifiant unique de l\'utilisateur' })
-    @PrimaryGeneratedColumn()
-    id: number;
+  @ApiProperty({
+    example: 1,
+    description: "Identifiant unique de l'utilisateur",
+  })
+  @PrimaryGeneratedColumn()
+  id: number;
 
-    @ApiProperty({ example: 'Doe', description: 'Nom de l\'utilisateur' })
-    @Column()
-    nom: string;
+  @ApiProperty({ example: 'Doe', description: "Nom de l'utilisateur" })
+  @Column()
+  nom: string;
 
-    @ApiProperty({ example: 'John', description: 'Prénom de l\'utilisateur' })
-    @Column()
-    prenom: string;
+  @ApiProperty({ example: 'John', description: "Prénom de l'utilisateur" })
+  @Column()
+  prenom: string;
 
-    @ApiProperty({ example: 'john.doe@example.com', description: 'Adresse email unique de l\'utilisateur' })
-    @Column()
-    email: string;
+  @ApiProperty({
+    example: 'john.doe@example.com',
+    description: "Adresse email unique de l'utilisateur",
+  })
+  @Column()
+  email: string;
 
-    // Le mot de passe n'est généralement pas exposé dans la documentation
-    @Column()
-    password: string;
+  @Column({ select: false })
+  password: string;
+
+  @OneToMany(() => VoyageEntity, (voyage) => voyage.user)
+  voyages: VoyageEntity[];
 }

--- a/src/auth/guards/jwt-auth.guard.ts
+++ b/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: process.env.JWT_SECRET || 'odysseygatejwtsecret',
+    });
+  }
+
+  async validate(payload: any) {
+    // Le payload doit contenir, par exemple, sub (id) et email
+    return { id: payload.sub, email: payload.email };
+  }
+}

--- a/src/core/database/typeorm.config.ts
+++ b/src/core/database/typeorm.config.ts
@@ -4,15 +4,15 @@ import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 
 export const typeOrmConfig = async (
-    configService: ConfigService,
+  configService: ConfigService,
 ): Promise<TypeOrmModuleOptions> => ({
-    type: 'mysql',
-    host: configService.get<string>('DB_HOST'),
-    port: parseInt(configService.get<string>('DB_PORT'), 10),
-    username: configService.get<string>('DB_USER'),
-    password: configService.get<string>('DB_PASS'),
-    database: configService.get<string>('DB_NAME'),
-    // Charge automatiquement toutes les entités dans le projet
-    entities: [__dirname + '/../../**/*.entity{.ts,.js}'],
-    synchronize: true, // Pour le développement (désactiver en production)
+  type: 'mysql',
+  host: configService.get<string>('DB_HOST'),
+  port: parseInt(configService.get<string>('DB_PORT'), 10),
+  username: configService.get<string>('DB_USER'),
+  password: configService.get<string>('DB_PASS'),
+  database: configService.get<string>('DB_NAME'),
+  entities: [__dirname + '/../../**/*.entity{.ts,.js}'],
+  synchronize: true,
 });
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,6 @@ async function bootstrap() {
     .setTitle('Odyssey Gate API')
     .setDescription("Documentation de l'API pour l'application Odyssey Gate")
     .setVersion('1.0')
-    // La configuration du Bearer Token
     .addBearerAuth(
       {
         type: 'http',
@@ -17,14 +16,14 @@ async function bootstrap() {
         bearerFormat: 'JWT',
         in: 'header',
       },
-      'access-token' // nom de la stratégie (sera utilisé dans les décorateurs que j'ai mis)
+      'access-token',
     )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api-docs', app, document);
 
-  // Et la redirection de la racine vers Swagger
+  // Redirection de la racine vers Swagger
   app.getHttpAdapter().get('/', (req, res) => {
     res.redirect('/api-docs');
   });

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,10 @@
+// src/types/express.d.ts
+import { Request } from 'express';
+
+export interface AuthenticatedRequest extends Request {
+  user: {
+    id: number;
+    email?: string;
+    [key: string]: any;
+  };
+}

--- a/src/voyage/dto/create-activite.dto.ts
+++ b/src/voyage/dto/create-activite.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional } from 'class-validator';
+
+export class CreateActiviteDto {
+  @ApiProperty({
+    example: 'Visite du Louvre',
+    description: 'Nom de l’activité',
+  })
+  @IsString()
+  nom: string;
+
+  @ApiProperty({
+    example: 'Visite guidée de l’un des plus grands musées du monde',
+    description: 'Description de l’activité',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  description?: string;
+}

--- a/src/voyage/dto/create-logement.dto.ts
+++ b/src/voyage/dto/create-logement.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional } from 'class-validator';
+
+export class CreateLogementDto {
+  @ApiProperty({
+    example: 'Hôtel Le Grand',
+    description: 'Nom ou type de logement',
+  })
+  @IsString()
+  nom: string;
+
+  @ApiProperty({
+    example: '123 Rue de Paris',
+    description: 'Adresse du logement',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  adresse?: string;
+}

--- a/src/voyage/dto/create-transport.dto.ts
+++ b/src/voyage/dto/create-transport.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional } from 'class-validator';
+
+export class CreateTransportDto {
+  @ApiProperty({
+    example: 'Avion',
+    description: 'Type de transport (ex: Avion, Train, Bus, etc.)',
+  })
+  @IsString()
+  type: string;
+
+  @ApiProperty({
+    example: 'Air France',
+    description: 'Nom de la compagnie de transport',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  compagnie?: string;
+}

--- a/src/voyage/dto/create-voyage.dto.ts
+++ b/src/voyage/dto/create-voyage.dto.ts
@@ -1,0 +1,106 @@
+// src/voyage/dto/create-voyage.dto.ts
+import {
+  IsString,
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+class TransportInfo {
+  @ApiProperty({ example: 'Train', description: 'Type de transport' })
+  @IsString()
+  type: string;
+
+  @ApiPropertyOptional({
+    example: 'SNCF',
+    description: 'Compagnie de transport',
+  })
+  @IsOptional()
+  @IsString()
+  compagnie?: string;
+}
+
+class LogementInfo {
+  @ApiProperty({ example: 'Hôtel XYZ', description: 'Nom du logement' })
+  @IsString()
+  nom: string;
+
+  @ApiPropertyOptional({
+    example: '12 rue de la Paix, Paris',
+    description: 'Adresse du logement',
+  })
+  @IsOptional()
+  @IsString()
+  adresse?: string;
+}
+
+class ActiviteInfo {
+  @ApiProperty({
+    example: 'Visite guidée',
+    description: "Description de l'activité",
+  })
+  @IsString()
+  description: string;
+
+  @ApiPropertyOptional({
+    example: 'Louvre, Paris',
+    description: "Lieu de l'activité",
+  })
+  @IsOptional()
+  @IsString()
+  lieu?: string;
+}
+
+export class CreateVoyageDto {
+  @ApiProperty({ example: 'Paris', description: 'Destination du voyage' })
+  @IsString()
+  destination: string;
+
+  @ApiProperty({
+    example: '2025-04-10',
+    description: 'Date de départ (format ISO)',
+  })
+  @IsDateString()
+  dateDepart: string;
+
+  @ApiProperty({
+    example: '2025-04-20',
+    description: "Date d'arrivée (format ISO)",
+  })
+  @IsDateString()
+  dateArrivee: string;
+
+  @ApiProperty({ example: 2, description: 'Nombre de voyageurs' })
+  @IsNumber()
+  nombreVoyageurs: number;
+
+  @ApiPropertyOptional({
+    description: 'Informations de transport',
+    type: TransportInfo,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => TransportInfo)
+  transport?: TransportInfo;
+
+  @ApiPropertyOptional({
+    description: 'Informations de logement',
+    type: LogementInfo,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => LogementInfo)
+  logement?: LogementInfo;
+
+  @ApiPropertyOptional({
+    description: "Informations d'activité",
+    type: ActiviteInfo,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ActiviteInfo)
+  activite?: ActiviteInfo;
+}

--- a/src/voyage/entities/activite.entity.ts
+++ b/src/voyage/entities/activite.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('activites')
+export class ActiviteEntity {
+  @PrimaryGeneratedColumn()
+  @ApiProperty({ example: 1, description: "Identifiant unique de l'activité" })
+  id: number;
+
+  @Column()
+  @ApiProperty({
+    example: 'Visite guidée',
+    description: "Description de l'activité",
+  })
+  description: string;
+
+  @Column({ nullable: true })
+  @ApiProperty({
+    example: 'Louvre, Paris',
+    description: "Lieu de l'activité",
+    required: false,
+  })
+  lieu?: string;
+}

--- a/src/voyage/entities/logement.entity.ts
+++ b/src/voyage/entities/logement.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('logements')
+export class LogementEntity {
+  @PrimaryGeneratedColumn()
+  @ApiProperty({ example: 1, description: 'Identifiant unique du logement' })
+  id: number;
+
+  @Column()
+  @ApiProperty({ example: 'Hôtel XYZ', description: 'Nom du logement' })
+  nom: string;
+
+  @Column({ nullable: true })
+  @ApiProperty({
+    example: '12 rue de la Paix, Paris',
+    description: 'Adresse du logement',
+    required: false,
+  })
+  adresse?: string;
+}

--- a/src/voyage/entities/transport.entity.ts
+++ b/src/voyage/entities/transport.entity.ts
@@ -1,0 +1,21 @@
+// src/voyage/entities/transport.entity.ts
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('transports')
+export class TransportEntity {
+  @PrimaryGeneratedColumn()
+  @ApiProperty({ example: 1, description: 'Identifiant unique du transport' })
+  id: number;
+
+  @Column()
+  @ApiProperty({ example: 'Train', description: 'Type de transport' })
+  type: string;
+
+  @Column({ nullable: true })
+  @ApiProperty({
+    example: 'SNCF',
+    description: 'Compagnie de transport (optionnel)',
+  })
+  compagnie?: string;
+}

--- a/src/voyage/entities/voyage.entity.ts
+++ b/src/voyage/entities/voyage.entity.ts
@@ -1,0 +1,94 @@
+// src/voyage/entities/voyage.entity.ts
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { UserEntity } from '../../auth/entities/user.entity';
+import { TransportEntity } from './transport.entity';
+import { LogementEntity } from './logement.entity';
+import { ActiviteEntity } from './activite.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('voyages')
+export class VoyageEntity {
+  @PrimaryGeneratedColumn()
+  @ApiProperty({ example: 1, description: 'Identifiant unique du voyage' })
+  id: number;
+
+  @Column()
+  @ApiProperty({ example: 'Paris', description: 'Destination du voyage' })
+  destination: string;
+
+  @Column()
+  @ApiProperty({
+    example: '2025-04-10T00:00:00.000Z',
+    description: 'Date de départ',
+  })
+  dateDepart: Date;
+
+  @Column()
+  @ApiProperty({
+    example: '2025-04-20T00:00:00.000Z',
+    description: "Date d'arrivée",
+  })
+  dateArrivee: Date;
+
+  @Column()
+  @ApiProperty({ example: 2, description: 'Nombre de voyageurs' })
+  nombreVoyageurs: number;
+
+  @ManyToOne(() => UserEntity, (user) => user.voyages, { eager: true })
+  @ApiProperty({
+    type: () => UserEntity,
+    description: 'Utilisateur propriétaire du voyage',
+  })
+  user: UserEntity;
+
+  @OneToOne(() => TransportEntity, {
+    cascade: true,
+    eager: true,
+    nullable: true,
+  })
+  @JoinColumn()
+  @ApiProperty({
+    type: () => TransportEntity,
+    description: 'Transport associé au voyage (optionnel)',
+  })
+  transport?: TransportEntity;
+
+  @OneToOne(() => LogementEntity, {
+    cascade: true,
+    eager: true,
+    nullable: true,
+  })
+  @JoinColumn()
+  @ApiProperty({
+    type: () => LogementEntity,
+    description: 'Logement associé au voyage (optionnel)',
+  })
+  logement?: LogementEntity;
+
+  @OneToOne(() => ActiviteEntity, {
+    cascade: true,
+    eager: true,
+    nullable: true,
+  })
+  @JoinColumn()
+  @ApiProperty({
+    type: () => ActiviteEntity,
+    description: 'Activité associée au voyage (optionnel)',
+  })
+  activite?: ActiviteEntity;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/voyage/voyage.controller.ts
+++ b/src/voyage/voyage.controller.ts
@@ -1,0 +1,44 @@
+import { Controller, Post, Body, Req, UseGuards } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { VoyageService } from './voyage.service';
+import { CreateVoyageDto } from './dto/create-voyage.dto';
+import { Request } from 'express';
+import { VoyageEntity } from './entities/voyage.entity';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+
+interface RequestWithUser extends Request {
+  user: {
+    id: number;
+    email: string;
+  };
+}
+
+@ApiTags('Voyages')
+@ApiBearerAuth('access-token')
+@Controller('voyages')
+export class VoyageController {
+  constructor(private readonly voyageService: VoyageService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({
+    summary: "Création d'un nouveau voyage avec toutes les informations",
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Le voyage a été créé avec succès.',
+    type: VoyageEntity,
+  })
+  async create(
+    @Body() createVoyageDto: CreateVoyageDto,
+    @Req() req: RequestWithUser,
+  ): Promise<VoyageEntity> {
+    const userId = req.user.id;
+    return this.voyageService.createVoyage(createVoyageDto, userId);
+  }
+}

--- a/src/voyage/voyage.module.ts
+++ b/src/voyage/voyage.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { VoyageController } from './voyage.controller';
+import { VoyageService } from './voyage.service';
+import { VoyageEntity } from './entities/voyage.entity';
+import { TransportEntity } from './entities/transport.entity';
+import { LogementEntity } from './entities/logement.entity';
+import { ActiviteEntity } from './entities/activite.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      VoyageEntity,
+      TransportEntity,
+      LogementEntity,
+      ActiviteEntity,
+    ]),
+  ],
+  controllers: [VoyageController],
+  providers: [VoyageService],
+})
+export class VoyageModule {}

--- a/src/voyage/voyage.service.ts
+++ b/src/voyage/voyage.service.ts
@@ -1,0 +1,78 @@
+// src/voyage/voyage.service.ts
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { VoyageEntity } from './entities/voyage.entity';
+import { CreateVoyageDto } from './dto/create-voyage.dto';
+import { UserEntity } from '../auth/entities/user.entity';
+import { TransportEntity } from './entities/transport.entity';
+import { LogementEntity } from './entities/logement.entity';
+import { ActiviteEntity } from './entities/activite.entity';
+
+@Injectable()
+export class VoyageService {
+  constructor(
+    @InjectRepository(VoyageEntity)
+    private readonly voyageRepository: Repository<VoyageEntity>,
+  ) {}
+
+  async createVoyage(
+    dto: CreateVoyageDto,
+    userId: number,
+  ): Promise<VoyageEntity> {
+    // Conversion des dates
+    const depart = new Date(dto.dateDepart);
+    const arrivee = new Date(dto.dateArrivee);
+    if (isNaN(depart.getTime()) || isNaN(arrivee.getTime())) {
+      throw new InternalServerErrorException('Format de date invalide.');
+    }
+
+    // Récupération de l'utilisateur complet depuis la BDD
+    const user = await this.voyageRepository.manager.findOne(UserEntity, {
+      where: { id: userId },
+    });
+    if (!user) {
+      throw new InternalServerErrorException(
+        `L'utilisateur avec l'id ${userId} n'existe pas.`,
+      );
+    }
+
+    // Création de l'entité Voyage
+    const voyage = this.voyageRepository.create({
+      destination: dto.destination,
+      dateDepart: depart,
+      dateArrivee: arrivee,
+      nombreVoyageurs: dto.nombreVoyageurs,
+      user,
+    });
+
+    // Création des entités associées si des informations sont fournies
+
+    // Transport
+    if (dto.transport) {
+      const transport = new TransportEntity();
+      transport.type = dto.transport.type;
+      transport.compagnie = dto.transport.compagnie;
+      voyage.transport = transport;
+    }
+
+    // Logement
+    if (dto.logement) {
+      const logement = new LogementEntity();
+      logement.nom = dto.logement.nom;
+      logement.adresse = dto.logement.adresse;
+      voyage.logement = logement;
+    }
+
+    // Activité
+    if (dto.activite) {
+      const activite = new ActiviteEntity();
+      // Correction apportée ici : utilisation de 'description' et 'lieu'
+      activite.description = dto.activite.description;
+      activite.lieu = dto.activite.lieu;
+      voyage.activite = activite;
+    }
+
+    return this.voyageRepository.save(voyage);
+  }
+}

--- a/test/auth/auth.service.spec.ts
+++ b/test/auth/auth.service.spec.ts
@@ -92,8 +92,9 @@ describe('AuthService - Login', () => {
     let jwtServiceMock: Partial<JwtService>;
 
     beforeEach(async () => {
+        // Définir findOne dans le mock pour qu'il soit disponible pour la méthode login
         userRepositoryMock = {
-            findOneBy: jest.fn(),
+            findOne: jest.fn(),
         };
         jwtServiceMock = {
             signAsync: jest.fn(),
@@ -117,13 +118,13 @@ describe('AuthService - Login', () => {
     });
 
     it('should throw UnauthorizedException if email not found', async () => {
-        (userRepositoryMock.findOneBy as jest.Mock).mockResolvedValue(null);
+        (userRepositoryMock.findOne as jest.Mock).mockResolvedValue(null);
         const dto: LoginDto = { email: 'notfound@example.com', password: 'test123' };
         await expect(authService.login(dto)).rejects.toThrow(UnauthorizedException);
     });
 
     it('should throw UnauthorizedException if password mismatch', async () => {
-        (userRepositoryMock.findOneBy as jest.Mock).mockResolvedValue({
+        (userRepositoryMock.findOne as jest.Mock).mockResolvedValue({
             id: 1,
             email: 'john.doe@example.com',
             password: 'hashedpassword',
@@ -135,7 +136,7 @@ describe('AuthService - Login', () => {
     });
 
     it('should return access_token if credentials are valid', async () => {
-        (userRepositoryMock.findOneBy as jest.Mock).mockResolvedValue({
+        (userRepositoryMock.findOne as jest.Mock).mockResolvedValue({
             id: 1,
             email: 'john.doe@example.com',
             password: 'hashedpassword',
@@ -148,3 +149,4 @@ describe('AuthService - Login', () => {
         expect(result).toEqual({ access_token: 'mockedToken' });
     });
 });
+

--- a/test/voyage/voyage.service.spec.ts
+++ b/test/voyage/voyage.service.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { VoyageService } from '../../src/voyage/voyage.service';
+import { VoyageEntity } from '../../src/voyage/entities/voyage.entity';
+import { Repository } from 'typeorm';
+import { CreateVoyageDto } from '../../src/voyage/dto/create-voyage.dto';
+
+type MockRepository<T = any> = {
+  [P in keyof Omit<Repository<T>, 'manager'>]?: jest.Mock;
+} & {
+  manager: {
+    findOne: jest.Mock;
+  };
+};
+
+describe('VoyageService', () => {
+  let service: VoyageService;
+  let voyageRepositoryMock: MockRepository<VoyageEntity>;
+
+  beforeEach(async () => {
+    voyageRepositoryMock = {
+      create: jest.fn(),
+      save: jest.fn(),
+      manager: {
+        findOne: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        VoyageService,
+        {
+          provide: getRepositoryToken(VoyageEntity),
+          useValue: voyageRepositoryMock,
+        },
+      ],
+    }).compile();
+
+    service = module.get<VoyageService>(VoyageService);
+  });
+
+  it('should create a new voyage', async () => {
+    const dto: CreateVoyageDto = {
+      destination: 'Paris',
+      dateDepart: '2025-04-10',
+      dateArrivee: '2025-04-20',
+      nombreVoyageurs: 2,
+    };
+
+    voyageRepositoryMock.manager.findOne.mockResolvedValue({
+      id: 1,
+      nom: 'Doe',
+      prenom: 'John',
+      email: 'john.doe@example.com',
+    });
+
+    // Simuler create et save
+    voyageRepositoryMock.create.mockImplementation((data) => data);
+    voyageRepositoryMock.save.mockImplementation(async (entity) => ({
+      ...entity,
+      id: 1,
+    }));
+
+    const result = await service.createVoyage(dto, 1);
+
+    expect(voyageRepositoryMock.manager.findOne).toHaveBeenCalledWith(
+      expect.any(Function), 
+      { where: { id: 1 } },
+    );
+
+    expect(voyageRepositoryMock.create).toHaveBeenCalledWith({
+      destination: 'Paris',
+      dateDepart: new Date('2025-04-10'),
+      dateArrivee: new Date('2025-04-20'),
+      nombreVoyageurs: 2,
+      user: {
+        id: 1,
+        nom: 'Doe',
+        prenom: 'John',
+        email: 'john.doe@example.com',
+      },
+    });
+
+    expect(voyageRepositoryMock.save).toHaveBeenCalled();
+    expect(result.id).toBe(1);
+    expect(result.destination).toBe('Paris');
+  });
+});


### PR DESCRIPTION
…s associations

- Protection de l’endpoint POST /voyages via JwtAuthGuard.
- Récupération de l'utilisateur authentifié dans la requête pour associer le voyage.
- Création des sous-entités associées (Transport, Logement, Activité) lors de la création du voyage.
- Mise à jour de la documentation Swagger pour faciliter le test avec le token JWT.